### PR TITLE
Bug/log out token

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,8 +143,8 @@ android {
         applicationId "com.volvo.cash"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 7
-        versionName "1.2.3"
+        versionCode 8
+        versionName "1.2.4"
         multiDexEnabled true
     }
     splits {

--- a/ios/VolvoCashClient.xcodeproj/project.pbxproj
+++ b/ios/VolvoCashClient.xcodeproj/project.pbxproj
@@ -953,12 +953,12 @@
 				CODE_SIGN_ENTITLEMENTS = VolvoCashClient/VolvoCashClient.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 47Q8J9BGC6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = VolvoCashClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -983,11 +983,11 @@
 				CODE_SIGN_ENTITLEMENTS = VolvoCashClient/VolvoCashClient.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 47Q8J9BGC6;
 				INFOPLIST_FILE = VolvoCashClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1131,14 +1131,14 @@
 				CODE_SIGN_ENTITLEMENTS = OneSignalNotificationServiceExtension/OneSignalNotificationServiceExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.volvo.cash.OneSignalNotificationServiceExtension;
@@ -1167,14 +1167,14 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 47Q8J9BGC6;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.volvo.cash.OneSignalNotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/screens/auth/SmsScreen.tsx
+++ b/src/screens/auth/SmsScreen.tsx
@@ -57,7 +57,9 @@ const SmsScreen = () => {
       <Alert
         visible={error}
         title="Código inválido o expirado"
-        message="Asegúrate que has escrito bien el código o vuelve a solicitar un código."
+        message={`Asegúrate que has escrito bien el código o vuelve a solicitar un código${
+          deviceToken ? '.' : ''
+        }`}
         confirmText="OK"
         onConfirm={() => dispatch(dismissError())}
       />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,3 @@
 export const SMS_CODE_LENGTH = 4;
-export const ANDROID_VERSION = 'v1.2.3 (7)';
-export const IOS_VERSION = 'v1.2.3 (15)';
+export const ANDROID_VERSION = 'v1.2.4 (8)';
+export const IOS_VERSION = 'v1.2.4 (16)';

--- a/src/utils/redux/auth/auth-reducer.ts
+++ b/src/utils/redux/auth/auth-reducer.ts
@@ -84,6 +84,7 @@ export default function (
       return {
         ...state,
         ...initialState,
+        pushToken: state.pushToken,
       };
     default:
       return state;


### PR DESCRIPTION
#### Contexto

Al cerrar sesion se eliminaba de la persistencia el token de los push, el cual era necesario en la ventana de ingresar codigo sms sino aparecia un error el API.

#### Notas

| ios | android | 
| --- | ------  |
|  -  |    -    |
